### PR TITLE
Heimdall fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,8 +197,8 @@ COPY --from=builder /root/.foundry/bin/* /home/whitehat/.foundry/bin/
 
 # Give the new folders whitehat ownership
 USER root
-RUN chown -R whitehat:whitehat /home/whitehat/.bifrost/bin/ /home/whitehat/.foundry/bin/ && \
-    chmod -R 755 /home/whitehat/.bifrost/bin/ /home/whitehat/.foundry/bin/
+RUN chown -R whitehat:whitehat /home/whitehat/.bifrost/ /home/whitehat/.foundry/ && \
+    chmod -R 755 /home/whitehat/.bifrost/ /home/whitehat/.foundry/
 USER whitehat
 
 # ENTRYPOINT ["/bin/bash"] is used to set the default command for the container to start a new Bash shell.

--- a/Dockerfile
+++ b/Dockerfile
@@ -195,6 +195,11 @@ RUN echo 'export PATH="$PATH:$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modu
 COPY --from=builder /root/.bifrost/bin/* /home/whitehat/.bifrost/bin/
 COPY --from=builder /root/.foundry/bin/* /home/whitehat/.foundry/bin/
 
+# Give the new folders whitehat ownership
+USER root
+RUN chown -R whitehat:whitehat /home/whitehat/.bifrost/bin/ /home/whitehat/.foundry/bin/ && \
+    chmod -R 755 /home/whitehat/.bifrost/bin/ /home/whitehat/.foundry/bin/
+USER whitehat
 
 # ENTRYPOINT ["/bin/bash"] is used to set the default command for the container to start a new Bash shell.
 # This ensures that when the container is run, the user will be dropped into an interactive Bash shell by default.

--- a/README.md
+++ b/README.md
@@ -159,5 +159,6 @@ This would get the relative path of the src folder where all the contracts are (
 # Troubleshooting
 For general information, go to [Troubleshooting](https://github.com/Deivitto/auditor-docker/wiki/Troubleshooting) section in the wiki
 - [v0.0.1: `yarn`: command not found](https://github.com/Deivitto/auditor-docker/wiki/Troubleshooting#yarn-command-not-found)
+- [v0.1.0: `heimdall`: error: failed to create file "/home/whitehat/.bifrost/config.toml".](https://github.com/Deivitto/auditor-docker/wiki/Troubleshooting#heimdall-failed-to-create-file)
 - [Parent system out of time](https://github.com/Deivitto/auditor-docker/wiki/Troubleshooting#parent-system-out-of-time)
 - [`code` not working](https://github.com/Deivitto/auditor-docker/wiki/Troubleshooting#code-not-working)

--- a/scripts/update_scripts.sh
+++ b/scripts/update_scripts.sh
@@ -3,7 +3,8 @@
 # Constants
 REPO_URL="https://github.com/Deivitto/auditor-docker.git"
 TEMP_DIR=$(mktemp -d)
-LOCAL_DIR="$(dirname "$0")/.."  # One level up to cover both scripts and templates
+LOCAL_DIR="$HOME"
+
 
 # Clone the repo to the temporary directory
 git clone "$REPO_URL" "$TEMP_DIR"

--- a/scripts/update_scripts.sh
+++ b/scripts/update_scripts.sh
@@ -61,8 +61,9 @@ check_differences() {
     fi
 }
 
-# Check differences for scripts and templates
+# Check differences for scripts
 check_differences "scripts"
+# Do the same for templates
 check_differences "templates"
 
 # Clean up

--- a/scripts/update_scripts.sh
+++ b/scripts/update_scripts.sh
@@ -5,7 +5,6 @@ REPO_URL="https://github.com/Deivitto/auditor-docker.git"
 TEMP_DIR=$(mktemp -d)
 LOCAL_DIR="$HOME"
 
-
 # Clone the repo to the temporary directory
 git clone "$REPO_URL" "$TEMP_DIR"
 


### PR DESCRIPTION
- Heimdall issue regarding ownership of .foundry and .bifrost folders solved by changing ownership in dockerfile
- Updater route changed to be always $HOME rather than parent, what in case of being called with the symbolic link, was the wrong folder
- Fix of the issuer regarding not using $HOME, so it couldn't find the template